### PR TITLE
feat(fe): 5303 - updated is-select-tree to angular18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "is-components-ngx",
       "version": "18.0.0",
       "dependencies": {
+        "@ali-hm/angular-tree-component": "^18.0.5",
         "@angular-devkit/core": "^18.2.2",
         "@angular/animations": "^18.2.2",
         "@angular/cdk": "^18.2.2",
@@ -18,7 +19,6 @@
         "@angular/platform-browser": "^18.2.2",
         "@angular/platform-browser-dynamic": "^18.2.2",
         "@angular/router": "^18.2.2",
-        "@circlon/angular-tree-component": "^11.0.4",
         "@intelstudios/css": "^4.0.0",
         "@intelstudios/font-awesome": "^6.1.1-1",
         "@intelstudios/text-utils": "^2.0.2",
@@ -71,6 +71,20 @@
       "resolved": "https://registry.npmjs.org/@aduh95/viz.js/-/viz.js-3.4.0.tgz",
       "integrity": "sha512-KI2nVf9JdwWCXqK6RVf+9/096G7VWN4Z84mnynlyZKao2xQENW8WNEjLmvdlxS5X8PNWXFC1zqwm7tveOXw/4A==",
       "dev": true
+    },
+    "node_modules/@ali-hm/angular-tree-component": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/@ali-hm/angular-tree-component/-/angular-tree-component-18.0.5.tgz",
+      "integrity": "sha512-ZhN9AAwLb3uht66seoK2FWOyLC5aVxgf6TczVdhm3HbmhmagAoEMlIq7mj79jsV4LfKESPraFvOq+EnA6G/3tg==",
+      "dependencies": {
+        "mobx": "~4.14.1",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=18.0.0",
+        "@angular/core": ">=18.0.0",
+        "mobx": "~4.14.1"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -3368,19 +3382,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@circlon/angular-tree-component": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@circlon/angular-tree-component/-/angular-tree-component-11.0.4.tgz",
-      "integrity": "sha512-Ck86mG6Z9eWG03RiOACDzrCjuzEDXU8rcEDi0aw0+Ku62x6ZY2mx8G0VX3CLEkS1BAXM2ef6luOIcoSKAKtDaA==",
-      "dependencies": {
-        "mobx": "~4.14.1",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=11.0.0",
-        "@angular/core": ">=11.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "private": true,
   "dependencies": {
+    "@ali-hm/angular-tree-component": "^18.0.5",
     "@angular-devkit/core": "^18.2.2",
     "@angular/animations": "^18.2.2",
     "@angular/cdk": "^18.2.2",
@@ -47,7 +48,6 @@
     "@angular/platform-browser": "^18.2.2",
     "@angular/platform-browser-dynamic": "^18.2.2",
     "@angular/router": "^18.2.2",
-    "@circlon/angular-tree-component": "^11.0.4",
     "@intelstudios/css": "^4.0.0",
     "@intelstudios/font-awesome": "^6.1.1-1",
     "@intelstudios/text-utils": "^2.0.2",

--- a/projects/is-select-tree/package.json
+++ b/projects/is-select-tree/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@intelstudios/select-tree",
-  "version": "13.1.5",
+  "version": "18.0.0",
   "dependencies": {
-    "tslib": "^2.0.0"
+    "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@angular/common": "^13.3.1",
-    "@angular/core": "^13.3.1",
-    "@circlon/angular-tree-component": "^11.0.0"
+    "@angular/common": ">=18.0.0",
+    "@angular/core": ">=18.0.0",
+    "@angular/platform-browser": ">=18.0.0",
+    "@ngx-translate/core": "^16.0.4",
+    "@ali-hm/angular-tree-component": "^18.0.5"
   }
 }

--- a/projects/is-select-tree/src/lib/is-select-tree-node.component.ts
+++ b/projects/is-select-tree/src/lib/is-select-tree-node.component.ts
@@ -6,7 +6,7 @@ import {
   OnInit
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { TreeNode } from '@circlon/angular-tree-component';
+import { TreeNode } from '@ali-hm/angular-tree-component';
 import { Subscription } from 'rxjs';
 import { IsSelectField, IsSelectTree, IsSelectTreeChangeEvent, IsSelectTreeNode } from './is-select-tree.models';
 

--- a/projects/is-select-tree/src/lib/is-select-tree.component.ts
+++ b/projects/is-select-tree/src/lib/is-select-tree.component.ts
@@ -8,7 +8,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { ITreeOptions, TreeComponent, TreeNode } from '@circlon/angular-tree-component';
+import { ITreeOptions, TreeComponent, TreeNode } from '@ali-hm/angular-tree-component';
 import { Subscription } from 'rxjs';
 import { IsSelectTree, IsSelectTreeChangeEvent, IsSelectTreeChanges, IsSelectTreeNode } from './is-select-tree.models';
 

--- a/projects/is-select-tree/src/lib/is-select-tree.module.ts
+++ b/projects/is-select-tree/src/lib/is-select-tree.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IsSelectTreeComponent } from './is-select-tree.component';
 import { IsSelectTreeNodeComponent } from './is-select-tree-node.component';
-import { TreeModule } from '@circlon/angular-tree-component';
+import { TreeModule } from '@ali-hm/angular-tree-component';
 import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,7 +18,7 @@ export class AppComponent implements OnInit {
     { title: 'Core UI', route: '/core-ui' },
     { title: 'Date Picker', route: '/datepicker' },
     { title: 'Editable textbox', route: '/editable-textbox' },
-    //{ title: 'Select Tree', route: '/select-tree' },
+    { title: 'Select Tree', route: '/select-tree' },
     //{ title: 'Select Tree DX', route: '/dx-select-tree' },
     { title: 'Modal', route: '/modal' },
     { title: 'Time Picker', route: '/timepicker' },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ export const routes: Routes = [
   { path: 'froala', loadChildren: () => import('./demo-froala/demo-froala.module').then(m => m.DemoFroalaRoutingModule) },
   { path: 'core-ui', loadChildren: () => import('./demo-core-ui/demo-core-ui.module').then(m => m.DemoCoreUIRoutingModule) },
   { path: 'editable-textbox', loadChildren: () => import('./demo-editable-textbox/demo-editable-textbox.module').then(m => m.DemoEditableTextboxRoutingModule) },
-  //{ path: 'select-tree', loadChildren: () => import('./demo-select-tree/demo-select-tree.module').then(m => m.DemoSelectTreeRoutingModule) },
+  { path: 'select-tree', loadChildren: () => import('./demo-select-tree/demo-select-tree.module').then(m => m.DemoSelectTreeRoutingModule) },
   //{ path: 'dx-select-tree', loadChildren: () => import('./demo-dx-select-tree/demo-dx-select-tree.module').then(m => m.DemoDxSelectTreeRoutingModule) },
   { path: 'modal', loadChildren: () => import('./demo-modal/demo-modal.module').then(m => m.DemoModalRoutingModule) },
   { path: 'timepicker', loadChildren: () => import('./demo-timepicker/demo-timepicker.module').then(m => m.DemoTimepickerRoutingModule) },

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,7 +10,7 @@
 
 @import "../node_modules/@intelstudios/font-awesome/fontawesome/css/all.css";
 
-@import "@circlon/angular-tree-component/css/angular-tree-component.css";
+@import '@ali-hm/angular-tree-component/css/angular-tree-component.css';
 
 @import '../node_modules/text-security/text-security.css';
 


### PR DESCRIPTION
Updated is-select-tree to angular18.

One major change is changing package circlon/angular-tree-component into ali-hm/angular-tree-component, which is fork of the original package which was abandoned. https://github.com/ali-hm/angular-tree-component